### PR TITLE
Data retention: prune old messages, cap Postgres disk growth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.db*
 .idea/
 teranode-p2p-poc
+
+# Local design/brainstorm specs — not shipped with code
+docs/superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,14 +86,18 @@ docker run -p 8080:8080 -v $(pwd)/config.yaml:/config.yaml teranode-p2p-poc
 ```
 
 ### Testing
-No test files currently exist in the codebase. When adding tests, use Go's standard testing framework:
 ```bash
-# Run tests (when they exist)
+# Run tests
 go test ./...
 
 # Run tests with coverage
 go test -cover ./...
 ```
+
+Some tests in `pkg/model` (e.g. `retention_test.go`) are DB integration tests gated on the
+`TERANODE_P2P_TEST_DSN` environment variable; they are skipped if it is unset. **`TERANODE_P2P_TEST_DSN`
+must point ONLY at a throwaway/local test database** — these tests call `drop_old_partitions`, which
+scans and drops old partitions across ALL partitioned tables in the target DB.
 
 ## Architecture Overview
 
@@ -128,7 +132,8 @@ The application requires `config.yaml` with these key sections:
 - `database`: PostgreSQL `host`, `port`, `user`, `password`, `name`, `sslmode`
 - `networks`: List of BSV network names; topics are generated per network
 - `redis` (optional): Cache layer
-- `performance`, `monitoring` (optional): Tuning knobs
+- `performance` (optional): Tuning knobs, including `partition_retention_months` (data retention window; see Runtime Behavior)
+- `monitoring` (optional): Tuning knobs
 
 Environment variables can override config values using `TERANODE_P2P_` prefix with underscores replacing dots.
 
@@ -147,6 +152,7 @@ PostgreSQL must be running externally — use `docker-compose -f docker-compose.
 - P2P node logs connected peer count every 2 minutes
 - WebSocket endpoint: `/ws`, Frontend served at `/`
 - Server automatically serves React build if available, falls back to legacy HTML
+- Data retention: `performance.partition_retention_months` (default 3) controls how much history is kept. A daily in-app pass drops old `node_statuses` partitions and row-DELETEs older rows from the plain message tables. `rejected_txes` was removed and is dropped on startup.
 
 ### Frontend Architecture
 - **React/TypeScript**: Modern component-based architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ This is a BSV Blockchain P2P networking component that provides:
 
 ### Core Components
 - **P2P Client** (`cmd/main.go`): Uses `github.com/bsv-blockchain/go-p2p-message-bus` (libp2p-based) with `/dnsaddr` bootstrap discovery; runs as a passive listener (`dht_mode: "off"`)
-- **Message Storage** (`pkg/model/`): PostgreSQL with GORM; only `node_statuses` is partitioned by month, other message tables are plain and pruned by time-based row retention
+- **Message Storage** (`pkg/model/`): PostgreSQL with GORM. `node_statuses` is always partitioned by month. The other message tables' shape (plain vs partitioned) varies by deployment: PROD has them PLAIN (built by GORM `AutoMigrate`), while `migrations/001` and the local docker DB provision them PARTITIONED. Retention detects each table's actual shape at runtime via `pg_class.relkind` (see below) rather than assuming either — the code handles both.
 - **Parser** (`pkg/parser/`): Decodes incoming P2P messages into typed records
 - **Batch Insert Service** (`pkg/service/`): Buffers DB writes for throughput; also computes stats
 - **HTTP API** (`pkg/http/`): REST API for querying stored messages
@@ -152,7 +152,7 @@ PostgreSQL must be running externally — use `docker-compose -f docker-compose.
 - P2P node logs connected peer count every 2 minutes
 - WebSocket endpoint: `/ws`, Frontend served at `/`
 - Server automatically serves React build if available, falls back to legacy HTML
-- Data retention: `performance.partition_retention_months` (default 3) controls how much history is kept. A daily in-app pass drops old `node_statuses` partitions and row-DELETEs older rows from the plain message tables. `rejected_txes` was removed and is dropped on startup.
+- Data retention: `performance.partition_retention_months` (default 3) controls how much history is kept. A daily in-app pass (plus a synchronous pass at startup, before P2P subscribe) ensures current+next partitions exist, then routes pruning per table by its *actual* runtime shape (`pg_class.relkind`, checked per table in `deleteOldRows`): partitioned tables (`relkind='p'`) are pruned by dropping old partitions (`drop_old_partitions`); plain tables (`relkind='r'`) are pruned by batched row DELETE; a table that doesn't exist in this deployment's schema is skipped silently. `node_statuses` is always partitioned; the remaining message tables (`blocks`, `block_headers`, `handshakes`, `mining_ons`, `subtrees`, `best_block_requests`) are checked individually since PROD has them plain while `migrations/001`/local docker have them partitioned. `rejected_txes` was removed and is dropped on startup.
 
 ### Frontend Architecture
 - **React/TypeScript**: Modern component-based architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ This is a BSV Blockchain P2P networking component that provides:
 
 ### Core Components
 - **P2P Client** (`cmd/main.go`): Uses `github.com/bsv-blockchain/go-p2p-message-bus` (libp2p-based) with `/dnsaddr` bootstrap discovery; runs as a passive listener (`dht_mode: "off"`)
-- **Message Storage** (`pkg/model/`): PostgreSQL with GORM, partitioned by month, with materialized views
+- **Message Storage** (`pkg/model/`): PostgreSQL with GORM; only `node_statuses` is partitioned by month, other message tables are plain and pruned by time-based row retention
 - **Parser** (`pkg/parser/`): Decodes incoming P2P messages into typed records
 - **Batch Insert Service** (`pkg/service/`): Buffers DB writes for throughput; also computes stats
 - **HTTP API** (`pkg/http/`): REST API for querying stored messages

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -151,10 +151,14 @@ func main() {
 		log.Errorf("Failed to ensure retention objects: %v — retention is impaired, disk usage may grow unbounded", err)
 	}
 
-	// Create partitions for current and next months if they don't exist
+	// Create partitions for current and next months if they don't exist.
+	// node_statuses is always partitioned by this app (created PARTITION BY RANGE above), so it
+	// is handled explicitly here. The other message tables' shape varies by deployment (plain in
+	// PROD via AutoMigrate, partitioned via migrations/001 / local docker) and is handled by the
+	// synchronous create_monthly_partitions() call below plus runtime relkind detection in
+	// pkg/model/retention.go — not by this loop.
 	log.Info("Creating database partitions for current month...")
 	currentTime := time.Now()
-	// Only node_statuses is partitioned; the rest are plain tables pruned by row DELETE.
 	partitionTables := []string{"node_statuses"}
 
 	for _, tableName := range partitionTables {
@@ -219,6 +223,18 @@ func main() {
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS network_activity_summary`)
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS peer_activity_summary`)
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS latest_block_heights`)
+
+	// Synchronously ensure current+next month partitions exist for EVERY partitioned table
+	// (relkind='p'), whatever this deployment's schema shape turns out to be — PROD has the
+	// message tables plain and only node_statuses partitioned, but migrations/001 and local
+	// docker have all of them partitioned. This must complete before the P2P client
+	// subscribes/starts accepting writes below, closing the startup race where an insert into
+	// a partitioned table could fail with "no partition found for row" if the async 24h
+	// retention goroutine hasn't run yet. create_monthly_partitions() is fast (metadata-only).
+	log.Info("Ensuring monthly partitions exist for all partitioned tables...")
+	if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
+		log.Errorf("Failed to create monthly partitions: %v", err)
+	}
 
 	retentionMonths := viper.GetInt("performance.partition_retention_months")
 	if retentionMonths < 1 {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,10 +147,15 @@ func main() {
 		log.Info("Database schema check completed")
 	}
 
+	if err := model.EnsureRetentionObjects(db, log); err != nil {
+		log.Warnf("Failed to ensure retention objects: %v", err)
+	}
+
 	// Create partitions for current and next months if they don't exist
 	log.Info("Creating database partitions for current month...")
 	currentTime := time.Now()
-	partitionTables := []string{"blocks", "block_headers", "handshakes", "mining_ons", "subtrees", "node_statuses"}
+	// Only node_statuses is partitioned; the rest are plain tables pruned by row DELETE.
+	partitionTables := []string{"node_statuses"}
 
 	for _, tableName := range partitionTables {
 		// Create partition for current month
@@ -214,6 +219,12 @@ func main() {
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS network_activity_summary`)
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS peer_activity_summary`)
 	db.Exec(`REFRESH MATERIALIZED VIEW IF EXISTS latest_block_heights`)
+
+	retentionMonths := viper.GetInt("performance.partition_retention_months")
+	if retentionMonths < 1 {
+		retentionMonths = 3
+	}
+	log.Infof("Data retention: keeping %d month(s)", retentionMonths)
 
 	// Initialize batch insert service
 	batchService := service.NewBatchInsertService(db, log, 1000, 5*time.Second)
@@ -522,22 +533,18 @@ func main() {
 		}
 	}()
 
-	// Create monthly partitions proactively
+	// Run retention (create partitions, drop old partitions, delete old rows) daily
 	go func() {
 		ticker := time.NewTicker(24 * time.Hour)
 		defer ticker.Stop()
 
-		// Run once on startup
-		if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
-			log.Errorf("Failed to create monthly partitions: %v", err)
-		}
+		// Run once on startup — reclaims the existing backlog immediately.
+		model.RunRetention(db, log, retentionMonths)
 
 		for {
 			select {
 			case <-ticker.C:
-				if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
-					log.Errorf("Failed to create monthly partitions: %v", err)
-				}
+				model.RunRetention(db, log, retentionMonths)
 			}
 		}
 	}()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -148,7 +148,7 @@ func main() {
 	}
 
 	if err := model.EnsureRetentionObjects(db, log); err != nil {
-		log.Warnf("Failed to ensure retention objects: %v", err)
+		log.Errorf("Failed to ensure retention objects: %v — retention is impaired, disk usage may grow unbounded", err)
 	}
 
 	// Create partitions for current and next months if they don't exist

--- a/config.yaml
+++ b/config.yaml
@@ -50,7 +50,7 @@ performance:
   batch_interval: 5  # Seconds between batch flushes
   stats_interval: 60  # Seconds between stats calculations
   materialized_view_refresh: 300  # Seconds between materialized view refreshes
-  partition_cleanup_days: 90  # Days to keep old partitions
+  partition_retention_months: 3  # Keep current + (N-1) prior months; older data is pruned
 
 # Monitoring
 monitoring:

--- a/migrations/003_retention.sql
+++ b/migrations/003_retention.sql
@@ -1,0 +1,75 @@
+-- 003_retention.sql
+-- Reference copy of the retention objects. The application installs these at startup via
+-- pkg/model/retention.go (EnsureRetentionObjects); this file exists for manual parity only.
+
+-- Remove the dead rejected_txes table (feature removed in commit a31e3e0).
+DROP TABLE IF EXISTS rejected_txes;
+
+-- Ensure current + next month partitions for every partitioned table (relkind='p').
+CREATE OR REPLACE FUNCTION create_monthly_partitions()
+RETURNS void AS $$
+DECLARE
+    parent record;
+    m int;
+    start_date date;
+    end_date date;
+    pname text;
+BEGIN
+    FOR parent IN
+        SELECT c.relname AS name FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'p' AND n.nspname = 'public'
+    LOOP
+        FOR m IN 0..1 LOOP
+            start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
+            end_date := start_date + interval '1 month';
+            pname := parent.name || '_' || to_char(start_date, 'YYYY_MM');
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname) THEN
+                EXECUTE format('CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+                    pname, parent.name, start_date, end_date);
+                RAISE NOTICE 'Created partition %', pname;
+            END IF;
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop month-partitions older than the retention window across all partitioned tables.
+CREATE OR REPLACE FUNCTION drop_old_partitions(keep_months int)
+RETURNS void AS $$
+DECLARE
+    parent record;
+    child record;
+    cutoff date;
+    part_month date;
+BEGIN
+    IF keep_months < 1 THEN
+        keep_months := 1;
+    END IF;
+    cutoff := date_trunc('month', CURRENT_DATE) - make_interval(months => keep_months - 1);
+
+    FOR parent IN
+        SELECT c.relname AS name FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'p' AND n.nspname = 'public'
+    LOOP
+        FOR child IN
+            SELECT c.relname AS name
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = parent.name
+              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_[0-9]{2}$')
+        LOOP
+            part_month := to_date(right(child.name, 7), 'YYYY_MM');
+            IF part_month < cutoff THEN
+                EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
+                RAISE NOTICE 'Dropped old partition %', child.name;
+            END IF;
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Plain tables (blocks, block_headers, handshakes, mining_ons, subtrees, best_block_requests)
+-- are pruned by batched row DELETE in the application (pkg/model/retention.go, deleteOldRows).

--- a/migrations/003_retention.sql
+++ b/migrations/003_retention.sql
@@ -24,7 +24,7 @@ BEGIN
             start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
             end_date := start_date + interval '1 month';
             pname := parent.name || '_' || to_char(start_date, 'YYYY_MM');
-            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname) THEN
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname AND relnamespace = 'public'::regnamespace) THEN
                 EXECUTE format('CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
                     pname, parent.name, start_date, end_date);
                 RAISE NOTICE 'Created partition %', pname;
@@ -59,13 +59,17 @@ BEGIN
             JOIN pg_class c ON c.oid = i.inhrelid
             JOIN pg_class p ON p.oid = i.inhparent
             WHERE p.relname = parent.name
-              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_[0-9]{2}$')
+              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_(0[1-9]|1[0-2])$')
         LOOP
-            part_month := to_date(right(child.name, 7), 'YYYY_MM');
-            IF part_month < cutoff THEN
-                EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
-                RAISE NOTICE 'Dropped old partition %', child.name;
-            END IF;
+            BEGIN
+                part_month := to_date(right(child.name, 7), 'YYYY_MM');
+                IF part_month < cutoff THEN
+                    EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
+                    RAISE NOTICE 'Dropped old partition %', child.name;
+                END IF;
+            EXCEPTION WHEN others THEN
+                CONTINUE;
+            END;
         END LOOP;
     END LOOP;
 END;

--- a/migrations/003_retention.sql
+++ b/migrations/003_retention.sql
@@ -3,9 +3,10 @@
 -- pkg/model/retention.go (EnsureRetentionObjects); this file exists for manual parity only.
 
 -- Remove the dead rejected_txes table (feature removed in commit a31e3e0).
-DROP TABLE IF EXISTS rejected_txes;
+DROP TABLE IF EXISTS public.rejected_txes;
 
--- Ensure current + next month partitions for every partitioned table (relkind='p').
+-- Ensure current + next month partitions for every partitioned table (relkind='p') that is
+-- also in this app's table allowlist.
 CREATE OR REPLACE FUNCTION create_monthly_partitions()
 RETURNS void AS $$
 DECLARE
@@ -15,10 +16,12 @@ DECLARE
     end_date date;
     pname text;
 BEGIN
+    SET LOCAL lock_timeout = '5s';
     FOR parent IN
         SELECT c.relname AS name FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relkind = 'p' AND n.nspname = 'public'
+          AND c.relname = ANY(ARRAY['blocks','block_headers','handshakes','mining_ons','subtrees','node_statuses'])
     LOOP
         FOR m IN 0..1 LOOP
             start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
@@ -34,7 +37,10 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Drop month-partitions older than the retention window across all partitioned tables.
+-- Drop month-partitions older than the retention window across all partitioned tables that are
+-- also in this app's table allowlist. Before dropping, double-checks the partition holds no
+-- in-window rows — protects against a partition whose actual bound is wider than its name
+-- suggests (dropping by name alone could otherwise destroy in-window rows).
 CREATE OR REPLACE FUNCTION drop_old_partitions(keep_months int)
 RETURNS void AS $$
 DECLARE
@@ -42,7 +48,9 @@ DECLARE
     child record;
     cutoff date;
     part_month date;
+    has_inwindow boolean;
 BEGIN
+    SET LOCAL lock_timeout = '5s';
     IF keep_months < 1 THEN
         keep_months := 1;
     END IF;
@@ -52,6 +60,7 @@ BEGIN
         SELECT c.relname AS name FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relkind = 'p' AND n.nspname = 'public'
+          AND c.relname = ANY(ARRAY['blocks','block_headers','handshakes','mining_ons','subtrees','node_statuses'])
     LOOP
         FOR child IN
             SELECT c.relname AS name
@@ -64,6 +73,11 @@ BEGIN
             BEGIN
                 part_month := to_date(right(child.name, 7), 'YYYY_MM');
                 IF part_month < cutoff THEN
+                    EXECUTE format('SELECT EXISTS(SELECT 1 FROM %I WHERE received_at >= %L)', child.name, cutoff) INTO has_inwindow;
+                    IF has_inwindow THEN
+                        RAISE WARNING 'drop_old_partitions: skipping % — holds in-window rows (received_at >= %)', child.name, cutoff;
+                        CONTINUE;
+                    END IF;
                     EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
                     RAISE NOTICE 'Dropped old partition %', child.name;
                 END IF;
@@ -78,7 +92,8 @@ $$ LANGUAGE plpgsql;
 
 -- Indexes referenced by the Go model tags (models_postgres.go) for tables whose shape varies
 -- by deployment (plain via AutoMigrate in PROD, partitioned via 001 locally). IF NOT EXISTS is
--- safe to run against either shape.
+-- safe to run against either shape. The application also executes these at startup (see
+-- pkg/model/retention.go, EnsureRetentionObjects) — this file is for manual/reference parity.
 CREATE INDEX IF NOT EXISTS idx_blockheaders_received_at ON block_headers (received_at);
 CREATE INDEX IF NOT EXISTS idx_handshakes_received_at ON handshakes (received_at);
 CREATE INDEX IF NOT EXISTS idx_miningons_received_at ON mining_ons (received_at);

--- a/migrations/003_retention.sql
+++ b/migrations/003_retention.sql
@@ -68,6 +68,7 @@ BEGIN
                     RAISE NOTICE 'Dropped old partition %', child.name;
                 END IF;
             EXCEPTION WHEN others THEN
+                RAISE WARNING 'drop_old_partitions: skipped %: %', child.name, SQLERRM;
                 CONTINUE;
             END;
         END LOOP;
@@ -75,5 +76,18 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Plain tables (blocks, block_headers, handshakes, mining_ons, subtrees, best_block_requests)
--- are pruned by batched row DELETE in the application (pkg/model/retention.go, deleteOldRows).
+-- Indexes referenced by the Go model tags (models_postgres.go) for tables whose shape varies
+-- by deployment (plain via AutoMigrate in PROD, partitioned via 001 locally). IF NOT EXISTS is
+-- safe to run against either shape.
+CREATE INDEX IF NOT EXISTS idx_blockheaders_received_at ON block_headers (received_at);
+CREATE INDEX IF NOT EXISTS idx_handshakes_received_at ON handshakes (received_at);
+CREATE INDEX IF NOT EXISTS idx_miningons_received_at ON mining_ons (received_at);
+CREATE INDEX IF NOT EXISTS idx_subtrees_received_at ON subtrees (received_at);
+CREATE INDEX IF NOT EXISTS idx_bestblock_received_at ON best_block_requests (received_at);
+
+-- Row shape (plain vs partitioned) for blocks, block_headers, handshakes, mining_ons, subtrees,
+-- and best_block_requests is detected at RUNTIME via pg_class.relkind (see
+-- pkg/model/retention.go, deleteOldRows / tableRelkind). Partitioned tables are pruned by
+-- dropping old partitions (drop_old_partitions); plain tables are pruned by batched row DELETE.
+-- Do not assume either shape here — PROD has these plain, migrations/001 and local docker have
+-- them partitioned.

--- a/pkg/model/models_postgres.go
+++ b/pkg/model/models_postgres.go
@@ -36,7 +36,7 @@ type BlockHeaderPG struct {
 	Timestamp      uint32    `gorm:"not null;index:idx_blockheaders_timestamp" json:"Timestamp"`
 	Bits           uint32    `gorm:"not null" json:"Bits"`
 	Nonce          uint64    `gorm:"not null" json:"Nonce"`
-	ReceivedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"ReceivedAt"`
+	ReceivedAt     time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index:idx_blockheaders_received_at" json:"ReceivedAt"`
 	CoinbaseValue  uint64    `gorm:"default:0" json:"CoinbaseValue"`
 	CoinbaseScript string    `gorm:"type:text" json:"CoinbaseScript"`
 	MinerAddress   string    `gorm:"type:varchar(100);index:idx_blockheaders_miner" json:"MinerAddress"`
@@ -59,7 +59,7 @@ type HandshakePG struct {
 	DataHubURL string    `gorm:"type:text" json:"DataHubURL"`
 	UserAgent  string    `gorm:"type:text" json:"UserAgent"`
 	Services   uint64    `gorm:"not null" json:"Services"`
-	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"ReceivedAt"`
+	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index:idx_handshakes_received_at" json:"ReceivedAt"`
 }
 
 func (HandshakePG) TableName() string {
@@ -78,7 +78,7 @@ type MiningOnPG struct {
 	Miner        string    `gorm:"type:varchar(100);index:idx_miningons_miner" json:"Miner"`
 	SizeInBytes  uint64    `gorm:"not null" json:"SizeInBytes"`
 	TxCount      uint64    `gorm:"not null" json:"TxCount"`
-	ReceivedAt   time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"ReceivedAt"`
+	ReceivedAt   time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index:idx_miningons_received_at" json:"ReceivedAt"`
 }
 
 func (MiningOnPG) TableName() string {
@@ -92,7 +92,7 @@ type SubtreePG struct {
 	Hash       string    `gorm:"type:varchar(64);not null;index:idx_subtrees_hash,type:hash" json:"Hash"`
 	DataHubURL string    `gorm:"type:text" json:"DataHubURL"`
 	PeerID     string    `gorm:"type:varchar(100);not null;index:idx_subtrees_peer_received" json:"PeerID"`
-	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"ReceivedAt"`
+	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index:idx_subtrees_received_at" json:"ReceivedAt"`
 }
 
 func (SubtreePG) TableName() string {
@@ -104,7 +104,7 @@ type BestBlockRequestPG struct {
 	ID         uint64    `gorm:"primaryKey;autoIncrement" json:"ID"`
 	Network    string    `gorm:"type:varchar(20);not null;index:idx_bestblock_network_received" json:"Network"`
 	PeerID     string    `gorm:"type:varchar(100);not null;index:idx_bestblock_peer_received" json:"PeerID"`
-	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP" json:"ReceivedAt"`
+	ReceivedAt time.Time `gorm:"not null;default:CURRENT_TIMESTAMP;index:idx_bestblock_received_at" json:"ReceivedAt"`
 }
 
 func (BestBlockRequestPG) TableName() string {

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -99,6 +99,41 @@ func EnsureRetentionObjects(db *gorm.DB, log *logrus.Logger) error {
 	return nil
 }
 
-// deleteOldRows and RunRetention are added in later tasks.
+// retentionCutoff returns the start of the month (current − (keepMonths−1)) in UTC.
+// Rows/partitions strictly older than this are pruned. keepMonths is floored at 1.
+func retentionCutoff(keepMonths int) time.Time {
+	if keepMonths < 1 {
+		keepMonths = 1
+	}
+	now := time.Now().UTC()
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	return firstOfMonth.AddDate(0, -(keepMonths - 1), 0)
+}
+
+// deleteOldRows removes rows older than the retention cutoff from each plain table, in
+// batches of 20000 to bound lock duration, WAL, and dead-tuple buildup. Table names must
+// come from a trusted allowlist (they are interpolated into SQL).
+func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []string) error {
+	cutoff := retentionCutoff(keepMonths)
+	for _, t := range tables {
+		var total int64
+		for {
+			sql := fmt.Sprintf(
+				"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE received_at < ? LIMIT 20000)",
+				t, t)
+			res := db.Exec(sql, cutoff)
+			if res.Error != nil {
+				return fmt.Errorf("delete old rows from %s: %w", t, res.Error)
+			}
+			total += res.RowsAffected
+			if res.RowsAffected == 0 {
+				break
+			}
+		}
+		log.Infof("retention: deleted %d rows older than %s from %s", total, cutoff.Format("2006-01-02"), t)
+	}
+	return nil
+}
+
+// RunRetention is added in a later task.
 var _ = plainTables
-var _ = time.Now

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -135,5 +135,16 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 	return nil
 }
 
-// RunRetention is added in a later task.
-var _ = plainTables
+// RunRetention runs one full prune pass: ensure partitions, drop old partitions, delete old
+// rows from plain tables. Errors are logged, not returned — retention must never crash the app.
+func RunRetention(db *gorm.DB, log *logrus.Logger, keepMonths int) {
+	if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
+		log.Errorf("retention: create_monthly_partitions failed: %v", err)
+	}
+	if err := db.Exec("SELECT drop_old_partitions(?)", keepMonths).Error; err != nil {
+		log.Errorf("retention: drop_old_partitions failed: %v", err)
+	}
+	if err := deleteOldRows(db, log, keepMonths, plainTables); err != nil {
+		log.Errorf("retention: deleteOldRows failed: %v", err)
+	}
+}

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -8,8 +8,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// plainTables are the non-partitioned message tables pruned by row DELETE.
-var plainTables = []string{
+// rowPruneCandidates are the message tables (excluding node_statuses) that MAY be pruned by
+// row DELETE. Whether a given table actually is plain (relkind='r') vs partitioned
+// (relkind='p') varies by deployment: PROD has these built PLAIN by GORM AutoMigrate, while
+// migrations/001 (and the local docker DB) provision them PARTITIONED. deleteOldRows decides
+// per-table, at runtime, via pg_class.relkind — never assume the shape here.
+var rowPruneCandidates = []string{
 	"blocks", "block_headers", "handshakes", "mining_ons", "subtrees", "best_block_requests",
 }
 
@@ -80,6 +84,7 @@ BEGIN
                     RAISE NOTICE 'Dropped old partition %', child.name;
                 END IF;
             EXCEPTION WHEN others THEN
+                RAISE WARNING 'drop_old_partitions: skipped %: %', child.name, SQLERRM;
                 CONTINUE;
             END;
         END LOOP;
@@ -105,6 +110,11 @@ func EnsureRetentionObjects(db *gorm.DB, log *logrus.Logger) error {
 
 // retentionCutoff returns the start of the month (current − (keepMonths−1)) in UTC.
 // Rows/partitions strictly older than this are pruned. keepMonths is floored at 1.
+//
+// Correctness depends on the DB session timezone matching this function's UTC basis:
+// the Go side uses time.Now().UTC(), the SQL side (create_monthly_partitions /
+// drop_old_partitions) uses CURRENT_DATE — they must agree. The DSN pins TimeZone=UTC
+// (cmd/main.go, and TERANODE_P2P_TEST_DSN for tests) to keep the two sides in sync.
 func retentionCutoff(keepMonths int) time.Time {
 	if keepMonths < 1 {
 		keepMonths = 1
@@ -119,15 +129,41 @@ func retentionCutoff(keepMonths int) time.Time {
 // should never be hit in practice and guards only against a pathological infinite loop.
 const deleteOldRowsMaxBatches = 100000
 
-// deleteOldRows removes rows older than the retention cutoff from each plain table, in
-// batches of 20000 to bound lock duration, WAL, and dead-tuple buildup. Table names must
-// come from a trusted allowlist (they are interpolated into SQL).
+// tableRelkind looks up the pg_class.relkind of a public-schema table/relation by name.
+// Returns ("", nil) if no such relation exists (never treat that as an error — a candidate
+// table absent in this deployment's schema is simply skipped).
+func tableRelkind(db *gorm.DB, table string) (string, error) {
+	var relkind string
+	err := db.Raw(
+		`SELECT c.relkind FROM pg_class c
+		 JOIN pg_namespace n ON n.oid = c.relnamespace
+		 WHERE n.nspname = 'public' AND c.relname = ?`, table).Scan(&relkind).Error
+	if err != nil {
+		return "", err
+	}
+	return relkind, nil
+}
+
+// deleteOldRows removes rows older than the retention cutoff, in batches of 20000 to bound
+// lock duration, WAL, and dead-tuple buildup. Table names must come from a trusted allowlist
+// (they are interpolated into SQL).
+//
+// Each candidate table's actual shape is checked at runtime via pg_class.relkind before any
+// DELETE is issued:
+//   - Table doesn't exist (no pg_class row) -> skipped silently, no error. Deployments vary
+//     in which message tables they even have.
+//   - relkind != 'r' (e.g. 'p' partitioned parent) -> skipped; partitioned tables are already
+//     pruned by drop_old_partitions (whole-partition DROP), and a row-DELETE there would be
+//     both redundant and, historically, unsafe (see below). Logged at Info, not Error.
+//   - relkind == 'r' (plain table) -> batched id-based DELETE proceeds as before.
 //
 // The DELETE predicate uses the id (BIGSERIAL PK) rather than ctid: ctid is only unique
 // within a single heap file, so on a PARTITIONED table the same ctid can identify unrelated
 // rows in other partitions, making a ctid-based batched delete unsafe for partitioned tables.
-// id is globally unique across the whole logical table (all partitions), so this is safe for
-// both plain and partitioned tables.
+// Since this function now only ever DELETEs from plain (relkind='r') tables, id is the sole
+// PK there and is genuinely globally unique for that table — the id-based batched delete is
+// correct. (On a partitioned table the PK is (id, received_at), and id alone is only unique
+// by shared-BIGSERIAL-sequence convention across partitions — but that path is skipped here.)
 //
 // A failure on one table is logged and does not abort the remaining tables; the function
 // returns a wrapped error listing which tables failed (nil if all succeeded).
@@ -135,6 +171,21 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 	cutoff := retentionCutoff(keepMonths)
 	var failed []string
 	for _, t := range tables {
+		relkind, err := tableRelkind(db, t)
+		if err != nil {
+			log.Errorf("retention: checking relkind for %s failed: %v", t, err)
+			failed = append(failed, t)
+			continue
+		}
+		if relkind == "" {
+			log.Debugf("retention: %s does not exist, skipping", t)
+			continue
+		}
+		if relkind != "r" {
+			log.Infof("retention: %s is partitioned (relkind=%s), skipping row-DELETE — handled by drop_old_partitions", t, relkind)
+			continue
+		}
+
 		var total int64
 		batches := 0
 		for {
@@ -169,7 +220,8 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 }
 
 // RunRetention runs one full prune pass: ensure partitions, drop old partitions, delete old
-// rows from plain tables. Errors are logged, not returned — retention must never crash the app.
+// rows from whichever candidate tables turn out to be plain (see deleteOldRows). Errors are
+// logged, not returned — retention must never crash the app.
 func RunRetention(db *gorm.DB, log *logrus.Logger, keepMonths int) {
 	if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
 		log.Errorf("retention: create_monthly_partitions failed: %v", err)
@@ -177,7 +229,7 @@ func RunRetention(db *gorm.DB, log *logrus.Logger, keepMonths int) {
 	if err := db.Exec("SELECT drop_old_partitions(?)", keepMonths).Error; err != nil {
 		log.Errorf("retention: drop_old_partitions failed: %v", err)
 	}
-	if err := deleteOldRows(db, log, keepMonths, plainTables); err != nil {
+	if err := deleteOldRows(db, log, keepMonths, rowPruneCandidates); err != nil {
 		log.Errorf("retention: deleteOldRows failed: %v", err)
 	}
 }

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -1,0 +1,104 @@
+package model
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
+)
+
+// plainTables are the non-partitioned message tables pruned by row DELETE.
+var plainTables = []string{
+	"blocks", "block_headers", "handshakes", "mining_ons", "subtrees", "best_block_requests",
+}
+
+// createMonthlyPartitionsSQL (re)defines a function that ensures the current and next
+// month partitions exist for every partitioned table (relkind='p') in the public schema.
+const createMonthlyPartitionsSQL = `
+CREATE OR REPLACE FUNCTION create_monthly_partitions()
+RETURNS void AS $$
+DECLARE
+    parent record;
+    m int;
+    start_date date;
+    end_date date;
+    pname text;
+BEGIN
+    FOR parent IN
+        SELECT c.relname AS name FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'p' AND n.nspname = 'public'
+    LOOP
+        FOR m IN 0..1 LOOP
+            start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
+            end_date := start_date + interval '1 month';
+            pname := parent.name || '_' || to_char(start_date, 'YYYY_MM');
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname) THEN
+                EXECUTE format('CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
+                    pname, parent.name, start_date, end_date);
+                RAISE NOTICE 'Created partition %', pname;
+            END IF;
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;`
+
+// dropOldPartitionsSQL (re)defines a function that drops month-partitions older than the
+// retention window across every partitioned table (relkind='p') in the public schema.
+const dropOldPartitionsSQL = `
+CREATE OR REPLACE FUNCTION drop_old_partitions(keep_months int)
+RETURNS void AS $$
+DECLARE
+    parent record;
+    child record;
+    cutoff date;
+    part_month date;
+BEGIN
+    IF keep_months < 1 THEN
+        keep_months := 1;
+    END IF;
+    cutoff := date_trunc('month', CURRENT_DATE) - make_interval(months => keep_months - 1);
+
+    FOR parent IN
+        SELECT c.relname AS name FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relkind = 'p' AND n.nspname = 'public'
+    LOOP
+        FOR child IN
+            SELECT c.relname AS name
+            FROM pg_inherits i
+            JOIN pg_class c ON c.oid = i.inhrelid
+            JOIN pg_class p ON p.oid = i.inhparent
+            WHERE p.relname = parent.name
+              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_[0-9]{2}$')
+        LOOP
+            part_month := to_date(right(child.name, 7), 'YYYY_MM');
+            IF part_month < cutoff THEN
+                EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
+                RAISE NOTICE 'Dropped old partition %', child.name;
+            END IF;
+        END LOOP;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;`
+
+// EnsureRetentionObjects installs the retention plpgsql functions and removes the dead
+// rejected_txes table (removed from the app in commit a31e3e0). Idempotent; safe every boot.
+func EnsureRetentionObjects(db *gorm.DB, log *logrus.Logger) error {
+	if err := db.Exec(createMonthlyPartitionsSQL).Error; err != nil {
+		return fmt.Errorf("create create_monthly_partitions: %w", err)
+	}
+	if err := db.Exec(dropOldPartitionsSQL).Error; err != nil {
+		return fmt.Errorf("create drop_old_partitions: %w", err)
+	}
+	if err := db.Exec("DROP TABLE IF EXISTS rejected_txes").Error; err != nil {
+		return fmt.Errorf("drop rejected_txes: %w", err)
+	}
+	log.Info("retention: SQL objects ensured, rejected_txes dropped if present")
+	return nil
+}
+
+// deleteOldRows and RunRetention are added in later tasks.
+var _ = plainTables
+var _ = time.Now

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -34,7 +34,7 @@ BEGIN
             start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
             end_date := start_date + interval '1 month';
             pname := parent.name || '_' || to_char(start_date, 'YYYY_MM');
-            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname) THEN
+            IF NOT EXISTS (SELECT 1 FROM pg_class WHERE relname = pname AND relnamespace = 'public'::regnamespace) THEN
                 EXECUTE format('CREATE TABLE %I PARTITION OF %I FOR VALUES FROM (%L) TO (%L)',
                     pname, parent.name, start_date, end_date);
                 RAISE NOTICE 'Created partition %', pname;
@@ -71,13 +71,17 @@ BEGIN
             JOIN pg_class c ON c.oid = i.inhrelid
             JOIN pg_class p ON p.oid = i.inhparent
             WHERE p.relname = parent.name
-              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_[0-9]{2}$')
+              AND c.relname ~ ('^' || parent.name || '_[0-9]{4}_(0[1-9]|1[0-2])$')
         LOOP
-            part_month := to_date(right(child.name, 7), 'YYYY_MM');
-            IF part_month < cutoff THEN
-                EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
-                RAISE NOTICE 'Dropped old partition %', child.name;
-            END IF;
+            BEGIN
+                part_month := to_date(right(child.name, 7), 'YYYY_MM');
+                IF part_month < cutoff THEN
+                    EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
+                    RAISE NOTICE 'Dropped old partition %', child.name;
+                END IF;
+            EXCEPTION WHEN others THEN
+                CONTINUE;
+            END;
         END LOOP;
     END LOOP;
 END;
@@ -110,27 +114,56 @@ func retentionCutoff(keepMonths int) time.Time {
 	return firstOfMonth.AddDate(0, -(keepMonths - 1), 0)
 }
 
+// deleteOldRowsMaxBatches is a defensive hard cap on the number of DELETE batches per table.
+// At 20000 rows/batch this bounds a single table to 2 billion rows before we bail out; it
+// should never be hit in practice and guards only against a pathological infinite loop.
+const deleteOldRowsMaxBatches = 100000
+
 // deleteOldRows removes rows older than the retention cutoff from each plain table, in
 // batches of 20000 to bound lock duration, WAL, and dead-tuple buildup. Table names must
 // come from a trusted allowlist (they are interpolated into SQL).
+//
+// The DELETE predicate uses the id (BIGSERIAL PK) rather than ctid: ctid is only unique
+// within a single heap file, so on a PARTITIONED table the same ctid can identify unrelated
+// rows in other partitions, making a ctid-based batched delete unsafe for partitioned tables.
+// id is globally unique across the whole logical table (all partitions), so this is safe for
+// both plain and partitioned tables.
+//
+// A failure on one table is logged and does not abort the remaining tables; the function
+// returns a wrapped error listing which tables failed (nil if all succeeded).
 func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []string) error {
 	cutoff := retentionCutoff(keepMonths)
+	var failed []string
 	for _, t := range tables {
 		var total int64
+		batches := 0
 		for {
+			batches++
+			if batches > deleteOldRowsMaxBatches {
+				log.Warnf("retention: %s exceeded %d batches, aborting this table's prune pass (deleted %d rows so far)", t, deleteOldRowsMaxBatches, total)
+				break
+			}
 			sql := fmt.Sprintf(
-				"DELETE FROM %s WHERE ctid IN (SELECT ctid FROM %s WHERE received_at < ? LIMIT 20000)",
+				"DELETE FROM %s WHERE id IN (SELECT id FROM %s WHERE received_at < ? LIMIT 20000)",
 				t, t)
 			res := db.Exec(sql, cutoff)
 			if res.Error != nil {
-				return fmt.Errorf("delete old rows from %s: %w", t, res.Error)
+				log.Errorf("retention: delete old rows from %s failed: %v", t, res.Error)
+				failed = append(failed, t)
+				break
 			}
 			total += res.RowsAffected
+			if res.RowsAffected > 0 {
+				log.Infof("retention: %s pruning, %d rows so far", t, total)
+			}
 			if res.RowsAffected == 0 {
 				break
 			}
 		}
 		log.Infof("retention: deleted %d rows older than %s from %s", total, cutoff.Format("2006-01-02"), t)
+	}
+	if len(failed) > 0 {
+		return fmt.Errorf("delete old rows failed for tables: %v", failed)
 	}
 	return nil
 }

--- a/pkg/model/retention.go
+++ b/pkg/model/retention.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -18,7 +19,8 @@ var rowPruneCandidates = []string{
 }
 
 // createMonthlyPartitionsSQL (re)defines a function that ensures the current and next
-// month partitions exist for every partitioned table (relkind='p') in the public schema.
+// month partitions exist for every partitioned table (relkind='p') in the public schema that
+// is also in this app's table allowlist.
 const createMonthlyPartitionsSQL = `
 CREATE OR REPLACE FUNCTION create_monthly_partitions()
 RETURNS void AS $$
@@ -29,10 +31,12 @@ DECLARE
     end_date date;
     pname text;
 BEGIN
+    SET LOCAL lock_timeout = '5s';
     FOR parent IN
         SELECT c.relname AS name FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relkind = 'p' AND n.nspname = 'public'
+          AND c.relname = ANY(ARRAY['blocks','block_headers','handshakes','mining_ons','subtrees','node_statuses'])
     LOOP
         FOR m IN 0..1 LOOP
             start_date := date_trunc('month', CURRENT_DATE) + make_interval(months => m);
@@ -49,7 +53,10 @@ END;
 $$ LANGUAGE plpgsql;`
 
 // dropOldPartitionsSQL (re)defines a function that drops month-partitions older than the
-// retention window across every partitioned table (relkind='p') in the public schema.
+// retention window across every partitioned table (relkind='p') in the public schema that is
+// also in this app's table allowlist. Before dropping, it double-checks the partition holds no
+// in-window rows — protects against a partition whose actual bound is wider than its name
+// suggests (dropping by name alone could otherwise destroy in-window rows).
 const dropOldPartitionsSQL = `
 CREATE OR REPLACE FUNCTION drop_old_partitions(keep_months int)
 RETURNS void AS $$
@@ -58,7 +65,9 @@ DECLARE
     child record;
     cutoff date;
     part_month date;
+    has_inwindow boolean;
 BEGIN
+    SET LOCAL lock_timeout = '5s';
     IF keep_months < 1 THEN
         keep_months := 1;
     END IF;
@@ -68,6 +77,7 @@ BEGIN
         SELECT c.relname AS name FROM pg_class c
         JOIN pg_namespace n ON n.oid = c.relnamespace
         WHERE c.relkind = 'p' AND n.nspname = 'public'
+          AND c.relname = ANY(ARRAY['blocks','block_headers','handshakes','mining_ons','subtrees','node_statuses'])
     LOOP
         FOR child IN
             SELECT c.relname AS name
@@ -80,6 +90,11 @@ BEGIN
             BEGIN
                 part_month := to_date(right(child.name, 7), 'YYYY_MM');
                 IF part_month < cutoff THEN
+                    EXECUTE format('SELECT EXISTS(SELECT 1 FROM %I WHERE received_at >= %L)', child.name, cutoff) INTO has_inwindow;
+                    IF has_inwindow THEN
+                        RAISE WARNING 'drop_old_partitions: skipping % — holds in-window rows (received_at >= %)', child.name, cutoff;
+                        CONTINUE;
+                    END IF;
                     EXECUTE format('DROP TABLE IF EXISTS %I', child.name);
                     RAISE NOTICE 'Dropped old partition %', child.name;
                 END IF;
@@ -92,8 +107,26 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;`
 
-// EnsureRetentionObjects installs the retention plpgsql functions and removes the dead
-// rejected_txes table (removed from the app in commit a31e3e0). Idempotent; safe every boot.
+// retentionReceivedAtIndexes creates the received_at index needed by deleteOldRows' DELETE
+// subquery on each row-prune candidate table that doesn't already get one from AutoMigrate
+// (models_postgres.go gorm tags cover the plain-shape deployments; deployments provisioned via
+// migrations/001 as partitioned tables never run AutoMigrate for these indexes). blocks and
+// node_statuses already have theirs created elsewhere and are intentionally excluded here.
+// Index names match the gorm tags in models_postgres.go exactly, so this is a no-op once
+// AutoMigrate (or a prior boot of this function) has created them.
+var retentionReceivedAtIndexes = []string{
+	"CREATE INDEX IF NOT EXISTS idx_blockheaders_received_at ON block_headers (received_at)",
+	"CREATE INDEX IF NOT EXISTS idx_handshakes_received_at ON handshakes (received_at)",
+	"CREATE INDEX IF NOT EXISTS idx_miningons_received_at ON mining_ons (received_at)",
+	"CREATE INDEX IF NOT EXISTS idx_subtrees_received_at ON subtrees (received_at)",
+	"CREATE INDEX IF NOT EXISTS idx_bestblock_received_at ON best_block_requests (received_at)",
+}
+
+// EnsureRetentionObjects installs the retention plpgsql functions, the received_at indexes the
+// row-prune DELETE subquery depends on, and removes the dead rejected_txes table (removed from
+// the app in commit a31e3e0). Idempotent; safe every boot. Runs synchronously at startup
+// pre-subscribe, so these are plain CREATE INDEX (not CONCURRENTLY) — blocking briefly is
+// acceptable here, and IF NOT EXISTS makes every statement a no-op once the index exists.
 func EnsureRetentionObjects(db *gorm.DB, log *logrus.Logger) error {
 	if err := db.Exec(createMonthlyPartitionsSQL).Error; err != nil {
 		return fmt.Errorf("create create_monthly_partitions: %w", err)
@@ -101,10 +134,15 @@ func EnsureRetentionObjects(db *gorm.DB, log *logrus.Logger) error {
 	if err := db.Exec(dropOldPartitionsSQL).Error; err != nil {
 		return fmt.Errorf("create drop_old_partitions: %w", err)
 	}
-	if err := db.Exec("DROP TABLE IF EXISTS rejected_txes").Error; err != nil {
+	for _, stmt := range retentionReceivedAtIndexes {
+		if err := db.Exec(stmt).Error; err != nil {
+			return fmt.Errorf("create received_at index (%s): %w", stmt, err)
+		}
+	}
+	if err := db.Exec("DROP TABLE IF EXISTS public.rejected_txes").Error; err != nil {
 		return fmt.Errorf("drop rejected_txes: %w", err)
 	}
-	log.Info("retention: SQL objects ensured, rejected_txes dropped if present")
+	log.Info("retention: SQL objects ensured, received_at indexes ensured, rejected_txes dropped if present")
 	return nil
 }
 
@@ -128,6 +166,16 @@ func retentionCutoff(keepMonths int) time.Time {
 // At 20000 rows/batch this bounds a single table to 2 billion rows before we bail out; it
 // should never be hit in practice and guards only against a pathological infinite loop.
 const deleteOldRowsMaxBatches = 100000
+
+// deleteOldRowsProgressLogEvery throttles the per-batch progress log in deleteOldRows to avoid
+// flooding logs on a large first run (e.g. ~406 batches pruning subtrees). The final per-table
+// total is always logged regardless of this throttle.
+const deleteOldRowsProgressLogEvery = 20
+
+// validTableName matches the safe subset of identifiers deleteOldRows will interpolate into
+// SQL. Table names come from the hardcoded rowPruneCandidates list, never user input, but this
+// is a defense-in-depth guard against a future caller passing something unexpected.
+var validTableName = regexp.MustCompile(`^[a-z_][a-z0-9_]*$`)
 
 // tableRelkind looks up the pg_class.relkind of a public-schema table/relation by name.
 // Returns ("", nil) if no such relation exists (never treat that as an error — a candidate
@@ -171,6 +219,12 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 	cutoff := retentionCutoff(keepMonths)
 	var failed []string
 	for _, t := range tables {
+		if !validTableName.MatchString(t) {
+			log.Errorf("retention: table name %q does not match %s, skipping", t, validTableName.String())
+			failed = append(failed, t)
+			continue
+		}
+
 		relkind, err := tableRelkind(db, t)
 		if err != nil {
 			log.Errorf("retention: checking relkind for %s failed: %v", t, err)
@@ -182,7 +236,7 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 			continue
 		}
 		if relkind != "r" {
-			log.Infof("retention: %s is partitioned (relkind=%s), skipping row-DELETE — handled by drop_old_partitions", t, relkind)
+			log.Infof("retention: skipping non-plain relation %s (relkind=%s)", t, relkind)
 			continue
 		}
 
@@ -204,7 +258,7 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 				break
 			}
 			total += res.RowsAffected
-			if res.RowsAffected > 0 {
+			if res.RowsAffected > 0 && batches%deleteOldRowsProgressLogEvery == 0 {
 				log.Infof("retention: %s pruning, %d rows so far", t, total)
 			}
 			if res.RowsAffected == 0 {
@@ -221,15 +275,26 @@ func deleteOldRows(db *gorm.DB, log *logrus.Logger, keepMonths int, tables []str
 
 // RunRetention runs one full prune pass: ensure partitions, drop old partitions, delete old
 // rows from whichever candidate tables turn out to be plain (see deleteOldRows). Errors are
-// logged, not returned — retention must never crash the app.
+// logged, not returned — retention must never crash the app. Regardless of per-step outcome, it
+// always emits one distinct high-signal line at the end so a failed pass is greppable even if
+// the per-step error logs above scroll out of view (disk can otherwise grow unbounded silently).
 func RunRetention(db *gorm.DB, log *logrus.Logger, keepMonths int) {
+	ok := true
 	if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
 		log.Errorf("retention: create_monthly_partitions failed: %v", err)
+		ok = false
 	}
 	if err := db.Exec("SELECT drop_old_partitions(?)", keepMonths).Error; err != nil {
 		log.Errorf("retention: drop_old_partitions failed: %v", err)
+		ok = false
 	}
 	if err := deleteOldRows(db, log, keepMonths, rowPruneCandidates); err != nil {
 		log.Errorf("retention: deleteOldRows failed: %v", err)
+		ok = false
+	}
+	if ok {
+		log.Infof("retention: pass completed OK")
+	} else {
+		log.Errorf("retention: pass completed WITH FAILURES — disk may grow unbounded, investigate")
 	}
 }

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -67,3 +67,65 @@ func TestEnsureRetentionObjectsIdempotent(t *testing.T) {
 		t.Fatalf("drop_old_partitions not callable: %v", err)
 	}
 }
+
+func TestDeleteOldRows(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+
+	if err := db.Exec("DROP TABLE IF EXISTS retention_prune_test").Error; err != nil {
+		t.Fatalf("drop temp: %v", err)
+	}
+	if err := db.Exec("CREATE TABLE retention_prune_test (id bigserial primary key, received_at timestamptz NOT NULL)").Error; err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS retention_prune_test") })
+
+	// Seed one row per month for the last 6 months plus this month, at day 15.
+	if err := db.Exec(`
+		INSERT INTO retention_prune_test (received_at)
+		SELECT date_trunc('month', now()) - make_interval(months => g) + interval '14 days'
+		FROM generate_series(0, 6) g`).Error; err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// keepMonths=3 -> cutoff = start of (this month - 2). Keep months offset 0,1,2 -> 3 rows.
+	if err := deleteOldRows(db, log, 3, []string{"retention_prune_test"}); err != nil {
+		t.Fatalf("deleteOldRows: %v", err)
+	}
+
+	var remaining int64
+	db.Raw("SELECT count(*) FROM retention_prune_test").Scan(&remaining)
+	if remaining != 3 {
+		t.Fatalf("expected 3 rows within 3-month window, got %d", remaining)
+	}
+
+	// A row exactly at the cutoff month boundary (offset 2, day 1) must be kept.
+	db.Exec("DELETE FROM retention_prune_test")
+	db.Exec(`INSERT INTO retention_prune_test (received_at)
+		VALUES (date_trunc('month', now()) - interval '2 months')`) // exactly at cutoff
+	if err := deleteOldRows(db, log, 3, []string{"retention_prune_test"}); err != nil {
+		t.Fatalf("deleteOldRows boundary: %v", err)
+	}
+	db.Raw("SELECT count(*) FROM retention_prune_test").Scan(&remaining)
+	if remaining != 1 {
+		t.Fatalf("cutoff-boundary row should be kept, got %d rows", remaining)
+	}
+}
+
+func TestDeleteOldRowsFloorsKeepMonths(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+	db.Exec("DROP TABLE IF EXISTS retention_floor_test")
+	db.Exec("CREATE TABLE retention_floor_test (id bigserial primary key, received_at timestamptz NOT NULL)")
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS retention_floor_test") })
+	// One row in the current month must survive keepMonths=0 (floored to 1).
+	db.Exec("INSERT INTO retention_floor_test (received_at) VALUES (now())")
+	if err := deleteOldRows(db, log, 0, []string{"retention_floor_test"}); err != nil {
+		t.Fatalf("deleteOldRows: %v", err)
+	}
+	var remaining int64
+	db.Raw("SELECT count(*) FROM retention_floor_test").Scan(&remaining)
+	if remaining != 1 {
+		t.Fatalf("keepMonths=0 must be floored to 1 and keep current month; got %d", remaining)
+	}
+}

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -127,5 +128,55 @@ func TestDeleteOldRowsFloorsKeepMonths(t *testing.T) {
 	db.Raw("SELECT count(*) FROM retention_floor_test").Scan(&remaining)
 	if remaining != 1 {
 		t.Fatalf("keepMonths=0 must be floored to 1 and keep current month; got %d", remaining)
+	}
+}
+
+func TestDropOldPartitions(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+	if err := EnsureRetentionObjects(db, log); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	db.Exec("DROP TABLE IF EXISTS retention_parts_test")
+	if err := db.Exec(`CREATE TABLE retention_parts_test (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`).Error; err != nil {
+		t.Fatalf("create partitioned: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS retention_parts_test") })
+
+	// One old partition (5 months ago), one current, one next — named <parent>_YYYY_MM.
+	mk := func(offset int) string {
+		var name string
+		db.Raw(`SELECT 'retention_parts_test_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => ?), 'YYYY_MM')`, offset).Scan(&name)
+		start := ""
+		end := ""
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offset).Scan(&start)
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offset+1).Scan(&end)
+		if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF retention_parts_test FOR VALUES FROM ('%s') TO ('%s')`, name, start, end)).Error; err != nil {
+			t.Fatalf("create partition %s: %v", name, err)
+		}
+		return name
+	}
+	oldName := mk(-5)
+	curName := mk(0)
+	nextName := mk(1)
+
+	if err := db.Exec("SELECT drop_old_partitions(3)").Error; err != nil {
+		t.Fatalf("drop_old_partitions: %v", err)
+	}
+
+	exists := func(name string) bool {
+		var n int64
+		db.Raw("SELECT count(*) FROM pg_class WHERE relname = ?", name).Scan(&n)
+		return n > 0
+	}
+	if exists(oldName) {
+		t.Fatalf("old partition %s should have been dropped", oldName)
+	}
+	if !exists(curName) {
+		t.Fatalf("current partition %s must be kept", curName)
+	}
+	if !exists(nextName) {
+		t.Fatalf("next partition %s must be kept", nextName)
 	}
 }

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -143,6 +143,107 @@ func TestRunRetention(t *testing.T) {
 	}
 	// Must not panic or block even when the plain tables are absent/empty; it logs and continues.
 	RunRetention(db, log, 3)
+
+	// Behavioral check: RunRetention actually prunes old rows from a plain-table-shaped table
+	// registered in plainTables' place via direct deleteOldRows call is covered elsewhere; here
+	// we verify RunRetention drives an end-to-end prune against a real plain table using the
+	// production plainTables list, by seeding one of them directly.
+	db.Exec("DROP TABLE IF EXISTS best_block_requests_run_retention_bak")
+	// Use the real best_block_requests table (part of plainTables) so RunRetention's internal
+	// call to deleteOldRows(plainTables) actually exercises it.
+	if err := db.Exec("CREATE TABLE IF NOT EXISTS best_block_requests (id bigserial primary key, network varchar(20) not null default 'test', peer_id varchar(100) not null default 'test', received_at timestamptz NOT NULL default now())").Error; err != nil {
+		t.Fatalf("ensure best_block_requests exists: %v", err)
+	}
+	db.Exec("DELETE FROM best_block_requests")
+	t.Cleanup(func() { db.Exec("DELETE FROM best_block_requests") })
+
+	if err := db.Exec(`INSERT INTO best_block_requests (network, peer_id, received_at)
+		VALUES ('test', 'test-peer', date_trunc('month', now()) - interval '12 months')`).Error; err != nil {
+		t.Fatalf("seed old row: %v", err)
+	}
+	if err := db.Exec(`INSERT INTO best_block_requests (network, peer_id, received_at)
+		VALUES ('test', 'test-peer', now())`).Error; err != nil {
+		t.Fatalf("seed current row: %v", err)
+	}
+
+	RunRetention(db, log, 3)
+
+	var remaining int64
+	db.Raw("SELECT count(*) FROM best_block_requests").Scan(&remaining)
+	if remaining != 1 {
+		t.Fatalf("RunRetention should have pruned the old row and kept the current one, got %d remaining rows", remaining)
+	}
+}
+
+// TestDeleteOldRowsPartitionSafe is a regression guard for the ctid-based batched delete bug:
+// ctid is only unique within a single heap file, so on a PARTITIONED table a ctid-based delete
+// can match and delete rows in the WRONG partition if they happen to share the same ctid slot.
+// This test forces that collision (both partitions' first row gets ctid (0,1)) and asserts the
+// in-window row survives. It FAILS against the old `WHERE ctid IN (...)` implementation and
+// PASSES against the id-based implementation.
+func TestDeleteOldRowsPartitionSafe(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+
+	const parent = "retention_delete_parts_test"
+	db.Exec("DROP TABLE IF EXISTS " + parent)
+	if err := db.Exec(fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`,
+		parent)).Error; err != nil {
+		t.Fatalf("create partitioned parent: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS " + parent) })
+
+	mkPartition := func(offsetMonths int) string {
+		var name, start, end string
+		db.Raw(`SELECT 'retention_delete_parts_test_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => ?), 'YYYY_MM')`, offsetMonths).Scan(&name)
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths).Scan(&start)
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths+1).Scan(&end)
+		if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('%s') TO ('%s')`, name, parent, start, end)).Error; err != nil {
+			t.Fatalf("create partition %s: %v", name, err)
+		}
+		return name
+	}
+
+	// OLD partition: well outside a 3-month retention window.
+	oldPart := mkPartition(-6)
+	// CURRENT partition: inside the 3-month window.
+	curPart := mkPartition(0)
+
+	// Insert exactly one row into each partition FIRST, so both land at ctid (0,1) within
+	// their respective partition's heap file — the collision the old ctid-based code missed.
+	oldTime := ""
+	db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => -6) + interval '10 days')::text`).Scan(&oldTime)
+	if err := db.Exec(fmt.Sprintf("INSERT INTO %s (received_at) VALUES (?)", parent), oldTime).Error; err != nil {
+		t.Fatalf("insert old row: %v", err)
+	}
+	curTime := ""
+	db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + interval '10 days')::text`).Scan(&curTime)
+	if err := db.Exec(fmt.Sprintf("INSERT INTO %s (received_at) VALUES (?)", parent), curTime).Error; err != nil {
+		t.Fatalf("insert current row: %v", err)
+	}
+
+	var oldCtid, curCtid string
+	db.Raw(fmt.Sprintf("SELECT ctid::text FROM %s", oldPart)).Scan(&oldCtid)
+	db.Raw(fmt.Sprintf("SELECT ctid::text FROM %s", curPart)).Scan(&curCtid)
+	if oldCtid != curCtid {
+		t.Fatalf("test setup invariant broken: expected both partitions' first row to share ctid, got old=%s cur=%s", oldCtid, curCtid)
+	}
+
+	if err := deleteOldRows(db, log, 3, []string{parent}); err != nil {
+		t.Fatalf("deleteOldRows: %v", err)
+	}
+
+	var oldRemaining, curRemaining int64
+	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", oldPart)).Scan(&oldRemaining)
+	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", curPart)).Scan(&curRemaining)
+
+	if oldRemaining != 0 {
+		t.Fatalf("old-partition row should have been deleted, got %d remaining", oldRemaining)
+	}
+	if curRemaining != 1 {
+		t.Fatalf("current-partition row must survive (partition-unsafe delete would have removed it), got %d remaining", curRemaining)
+	}
 }
 
 func TestDropOldPartitions(t *testing.T) {

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -11,19 +12,35 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// testDSNHostRE extracts the `host=...` field from a libpq key=value DSN string (the format
+// used throughout this package and by TERANODE_P2P_TEST_DSN). A simple field parse — no new
+// deps needed for this guard.
+var testDSNHostRE = regexp.MustCompile(`host=(\S+)`)
+
 // testDB connects to the DSN in TERANODE_P2P_TEST_DSN, or skips the test if unset.
 // Start one with: docker-compose -f docker-compose.postgres.yml up -d
 // then: TERANODE_P2P_TEST_DSN="host=localhost port=5432 user=teranode password=teranode dbname=teranode_p2p sslmode=disable TimeZone=UTC"
 //
 // WARNING: TERANODE_P2P_TEST_DSN must point ONLY at a throwaway/local test database. These
-// tests call drop_old_partitions, which scans and drops old partitions across ALL partitioned
-// tables in the target DB — pointing this at a real/shared database will drop real data.
+// tests call drop_old_partitions, which scans and drops old partitions across ALL allowlisted
+// partitioned tables in the target DB — pointing this at a real/shared database will drop real
+// data. As a guard, testDB refuses to connect to any non-local host unless
+// TERANODE_P2P_TEST_ALLOW_REMOTE=1 is explicitly set (see the host check below).
 func testDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	dsn := os.Getenv("TERANODE_P2P_TEST_DSN")
 	if dsn == "" {
 		t.Skip("TERANODE_P2P_TEST_DSN not set; skipping DB integration test")
 	}
+
+	host := ""
+	if m := testDSNHostRE.FindStringSubmatch(dsn); m != nil {
+		host = m[1]
+	}
+	if host != "localhost" && host != "127.0.0.1" && os.Getenv("TERANODE_P2P_TEST_ALLOW_REMOTE") != "1" {
+		t.Fatalf("refusing to run destructive retention tests against non-local host %q; set TERANODE_P2P_TEST_ALLOW_REMOTE=1 to override", host)
+	}
+
 	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
 		Logger:                 logger.Default.LogMode(logger.Silent),
 		SkipDefaultTransaction: true,
@@ -314,52 +331,198 @@ func TestDeleteOldRowsRoutesByShape(t *testing.T) {
 	// nil above already covering all three tables in one call.
 }
 
-func TestDropOldPartitions(t *testing.T) {
+// mkAgedPartition creates a range partition of parent named "<parent>_YYYY_MM" for the month
+// CURRENT_DATE+offsetMonths, with bounds exactly matching that calendar month (the "well-behaved"
+// case: name and bound agree). Returns the partition's relname.
+func mkAgedPartition(t *testing.T, db *gorm.DB, parent string, offsetMonths int) string {
+	t.Helper()
+	var name, start, end string
+	db.Raw(`SELECT ? || '_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => ?), 'YYYY_MM')`, parent, offsetMonths).Scan(&name)
+	db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths).Scan(&start)
+	db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths+1).Scan(&end)
+	if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('%s') TO ('%s')`, name, parent, start, end)).Error; err != nil {
+		t.Fatalf("create partition %s: %v", name, err)
+	}
+	return name
+}
+
+func partitionExists(db *gorm.DB, name string) bool {
+	var n int64
+	db.Raw("SELECT count(*) FROM pg_class WHERE relname = ?", name).Scan(&n)
+	return n > 0
+}
+
+// TestDropOldPartitionsSkipsNonAllowlisted is the regression test for B: create_monthly_partitions
+// and drop_old_partitions now only ever touch the six hardcoded app table names. A partitioned
+// table with a name OUTSIDE that allowlist must be left completely untouched by
+// drop_old_partitions, even though it satisfies relkind='p' and has an old-named partition that
+// would otherwise be dropped.
+func TestDropOldPartitionsSkipsNonAllowlisted(t *testing.T) {
 	db := testDB(t)
 	log := testLog()
 	if err := EnsureRetentionObjects(db, log); err != nil {
 		t.Fatalf("ensure: %v", err)
 	}
 
-	db.Exec("DROP TABLE IF EXISTS retention_parts_test")
-	if err := db.Exec(`CREATE TABLE retention_parts_test (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`).Error; err != nil {
+	const parent = "retention_parts_test" // deliberately NOT in the allowlist
+	db.Exec("DROP TABLE IF EXISTS " + parent)
+	if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`, parent)).Error; err != nil {
 		t.Fatalf("create partitioned: %v", err)
 	}
-	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS retention_parts_test") })
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS " + parent) })
 
-	// One old partition (5 months ago), one current, one next — named <parent>_YYYY_MM.
-	mk := func(offset int) string {
-		var name string
-		db.Raw(`SELECT 'retention_parts_test_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => ?), 'YYYY_MM')`, offset).Scan(&name)
-		start := ""
-		end := ""
-		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offset).Scan(&start)
-		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offset+1).Scan(&end)
-		if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF retention_parts_test FOR VALUES FROM ('%s') TO ('%s')`, name, start, end)).Error; err != nil {
-			t.Fatalf("create partition %s: %v", name, err)
-		}
-		return name
-	}
-	oldName := mk(-5)
-	curName := mk(0)
-	nextName := mk(1)
+	oldName := mkAgedPartition(t, db, parent, -5)
+	curName := mkAgedPartition(t, db, parent, 0)
+	nextName := mkAgedPartition(t, db, parent, 1)
 
 	if err := db.Exec("SELECT drop_old_partitions(3)").Error; err != nil {
 		t.Fatalf("drop_old_partitions: %v", err)
 	}
 
-	exists := func(name string) bool {
-		var n int64
-		db.Raw("SELECT count(*) FROM pg_class WHERE relname = ?", name).Scan(&n)
-		return n > 0
+	// None of the partitions should have moved — the parent name isn't in the allowlist, so
+	// drop_old_partitions never even looks at it.
+	if !partitionExists(db, oldName) {
+		t.Fatalf("old partition %s of a non-allowlisted table must survive (not in allowlist -> untouched)", oldName)
 	}
-	if exists(oldName) {
-		t.Fatalf("old partition %s should have been dropped", oldName)
-	}
-	if !exists(curName) {
+	if !partitionExists(db, curName) {
 		t.Fatalf("current partition %s must be kept", curName)
 	}
-	if !exists(nextName) {
+	if !partitionExists(db, nextName) {
 		t.Fatalf("next partition %s must be kept", nextName)
 	}
+}
+
+// withSwappedAllowlistedTable runs fn inside a transaction in which the REAL allowlisted table
+// `name` (e.g. "subtrees") — and all of its existing child partitions — have been renamed out of
+// the way, so `name` (and the same "_YYYY_MM" partition names the test will create) are free for
+// the test to reuse as a throwaway partitioned table. This exercises the actual
+// create_monthly_partitions / drop_old_partitions DROP code path — the allowlist matches on
+// exact relname, so there is no way to exercise the "this name IS allowlisted, and gets dropped"
+// branch other than using one of the six real names. ALTER TABLE ... RENAME only renames the
+// named relation, not its children, so existing partitions (e.g. subtrees_2026_07) must be
+// renamed individually too or the test's same-named replacement partitions collide with them.
+//
+// The whole thing runs in one transaction that is ALWAYS rolled back (never committed), so the
+// real table, its partitions, and their data are unconditionally restored — including if fn
+// calls t.Fatalf, since t.Fatalf only unwinds this goroutine via runtime.Goexit while deferred
+// rollback still runs. This is deliberately safer than a rename-then-restore-in-Cleanup approach,
+// which would leave a crash-shaped window where the real table is temporarily missing.
+func withSwappedAllowlistedTable(t *testing.T, db *gorm.DB, name string, fn func(tx *gorm.DB)) {
+	t.Helper()
+	tx := db.Begin()
+	if tx.Error != nil {
+		t.Fatalf("begin tx: %v", tx.Error)
+	}
+	defer tx.Rollback()
+
+	suffix := "_test_backup_" + fmt.Sprint(os.Getpid())
+
+	var children []string
+	if err := tx.Raw(
+		`SELECT c.relname FROM pg_inherits i
+		 JOIN pg_class c ON c.oid = i.inhrelid
+		 JOIN pg_class p ON p.oid = i.inhparent
+		 WHERE p.relname = ?`, name).Scan(&children).Error; err != nil {
+		t.Fatalf("list existing children of %s: %v", name, err)
+	}
+	for _, child := range children {
+		if err := tx.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO %s", child, child+suffix)).Error; err != nil {
+			t.Fatalf("rename real child %s out of the way: %v", child, err)
+		}
+	}
+
+	if err := tx.Exec(fmt.Sprintf("ALTER TABLE %s RENAME TO %s", name, name+suffix)).Error; err != nil {
+		t.Fatalf("rename real %s out of the way: %v", name, err)
+	}
+
+	fn(tx)
+}
+
+// TestDropOldPartitionsDropsAllowlisted proves the actual drop path fires for a table whose name
+// IS in the allowlist (B's complement: allowlisted names still work normally). Runs entirely
+// inside a rolled-back transaction against the real "subtrees" table name — see
+// withSwappedAllowlistedTable for why that's safe.
+func TestDropOldPartitionsDropsAllowlisted(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+	if err := EnsureRetentionObjects(db, log); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	withSwappedAllowlistedTable(t, db, "subtrees", func(tx *gorm.DB) {
+		if err := tx.Exec(`CREATE TABLE subtrees (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`).Error; err != nil {
+			t.Fatalf("create throwaway subtrees: %v", err)
+		}
+
+		oldName := mkAgedPartition(t, tx, "subtrees", -5)
+		curName := mkAgedPartition(t, tx, "subtrees", 0)
+		nextName := mkAgedPartition(t, tx, "subtrees", 1)
+
+		if err := tx.Exec("SELECT drop_old_partitions(3)").Error; err != nil {
+			t.Fatalf("drop_old_partitions: %v", err)
+		}
+
+		if partitionExists(tx, oldName) {
+			t.Fatalf("old partition %s of allowlisted table subtrees should have been dropped", oldName)
+		}
+		if !partitionExists(tx, curName) {
+			t.Fatalf("current partition %s must be kept", curName)
+		}
+		if !partitionExists(tx, nextName) {
+			t.Fatalf("next partition %s must be kept", nextName)
+		}
+	})
+}
+
+// TestDropOldPartitionsGuardsInWindowBound is the regression test for G: drop_old_partitions
+// selects candidates by parsing the "_YYYY_MM" name suffix, but must not trust the name alone —
+// it double-checks the partition's actual rows before dropping. This creates a partition NAMED
+// as old (5 months back, outside a 3-month window) but whose actual FOR VALUES bound extends
+// into the retention window, inserts an in-window row into it, and asserts drop_old_partitions
+// leaves it alone (the in-window row survives) despite the misleading name.
+func TestDropOldPartitionsGuardsInWindowBound(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+	if err := EnsureRetentionObjects(db, log); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	withSwappedAllowlistedTable(t, db, "subtrees", func(tx *gorm.DB) {
+		if err := tx.Exec(`CREATE TABLE subtrees (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`).Error; err != nil {
+			t.Fatalf("create throwaway subtrees: %v", err)
+		}
+
+		// Partition named "_YYYY_MM" for 5 months ago (outside a 3-month window, so its NAME
+		// says "drop me"), but its actual bound runs from 5 months ago all the way to NOW +
+		// 1 month — i.e. it also covers the entire in-window period.
+		var mispartName, start, end string
+		tx.Raw(`SELECT 'subtrees_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => -5), 'YYYY_MM')`).Scan(&mispartName)
+		tx.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => -5))::text`).Scan(&start)
+		tx.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => 2))::text`).Scan(&end)
+		if err := tx.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF subtrees FOR VALUES FROM ('%s') TO ('%s')`, mispartName, start, end)).Error; err != nil {
+			t.Fatalf("create mis-bounded partition: %v", err)
+		}
+
+		// Insert an in-window row (today) into the mis-bounded partition via the parent.
+		if err := tx.Exec("INSERT INTO subtrees (received_at) VALUES (now())").Error; err != nil {
+			t.Fatalf("insert in-window row: %v", err)
+		}
+		var rowCount int64
+		tx.Raw(fmt.Sprintf("SELECT count(*) FROM %s", mispartName)).Scan(&rowCount)
+		if rowCount != 1 {
+			t.Fatalf("test setup invariant broken: expected the in-window row to land in %s, got %d rows there", mispartName, rowCount)
+		}
+
+		if err := tx.Exec("SELECT drop_old_partitions(3)").Error; err != nil {
+			t.Fatalf("drop_old_partitions: %v", err)
+		}
+
+		if !partitionExists(tx, mispartName) {
+			t.Fatalf("partition %s holds an in-window row despite its old-looking name; it must NOT be dropped", mispartName)
+		}
+		tx.Raw(fmt.Sprintf("SELECT count(*) FROM %s", mispartName)).Scan(&rowCount)
+		if rowCount != 1 {
+			t.Fatalf("in-window row must survive in %s, got %d rows", mispartName, rowCount)
+		}
+	})
 }

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -131,6 +131,16 @@ func TestDeleteOldRowsFloorsKeepMonths(t *testing.T) {
 	}
 }
 
+func TestRunRetention(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+	if err := EnsureRetentionObjects(db, log); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	// Must not panic or block even when the plain tables are absent/empty; it logs and continues.
+	RunRetention(db, log, 3)
+}
+
 func TestDropOldPartitions(t *testing.T) {
 	db := testDB(t)
 	log := testLog()

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -14,6 +14,10 @@ import (
 // testDB connects to the DSN in TERANODE_P2P_TEST_DSN, or skips the test if unset.
 // Start one with: docker-compose -f docker-compose.postgres.yml up -d
 // then: TERANODE_P2P_TEST_DSN="host=localhost port=5432 user=teranode password=teranode dbname=teranode_p2p sslmode=disable TimeZone=UTC"
+//
+// WARNING: TERANODE_P2P_TEST_DSN must point ONLY at a throwaway/local test database. These
+// tests call drop_old_partitions, which scans and drops old partitions across ALL partitioned
+// tables in the target DB — pointing this at a real/shared database will drop real data.
 func testDB(t *testing.T) *gorm.DB {
 	t.Helper()
 	dsn := os.Getenv("TERANODE_P2P_TEST_DSN")

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -1,0 +1,69 @@
+package model
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// testDB connects to the DSN in TERANODE_P2P_TEST_DSN, or skips the test if unset.
+// Start one with: docker-compose -f docker-compose.postgres.yml up -d
+// then: TERANODE_P2P_TEST_DSN="host=localhost port=5432 user=teranode password=teranode dbname=teranode_p2p sslmode=disable TimeZone=UTC"
+func testDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dsn := os.Getenv("TERANODE_P2P_TEST_DSN")
+	if dsn == "" {
+		t.Skip("TERANODE_P2P_TEST_DSN not set; skipping DB integration test")
+	}
+	db, err := gorm.Open(postgres.Open(dsn), &gorm.Config{
+		Logger:                 logger.Default.LogMode(logger.Silent),
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("connect test db: %v", err)
+	}
+	return db
+}
+
+func testLog() *logrus.Logger {
+	l := logrus.New()
+	l.SetLevel(logrus.WarnLevel)
+	return l
+}
+
+func TestEnsureRetentionObjectsIdempotent(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+
+	// A leftover rejected_txes must be removed.
+	if err := db.Exec("CREATE TABLE IF NOT EXISTS rejected_txes (id bigserial primary key, received_at timestamptz)").Error; err != nil {
+		t.Fatalf("seed rejected_txes: %v", err)
+	}
+
+	// Run twice; second run must be a clean no-op.
+	for i := 0; i < 2; i++ {
+		if err := EnsureRetentionObjects(db, log); err != nil {
+			t.Fatalf("EnsureRetentionObjects run %d: %v", i, err)
+		}
+	}
+
+	var n int64
+	if err := db.Raw("SELECT count(*) FROM pg_class WHERE relname = 'rejected_txes'").Scan(&n).Error; err != nil {
+		t.Fatalf("check rejected_txes: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("rejected_txes still present after EnsureRetentionObjects")
+	}
+
+	// Both functions must exist and be callable.
+	if err := db.Exec("SELECT create_monthly_partitions()").Error; err != nil {
+		t.Fatalf("create_monthly_partitions not callable: %v", err)
+	}
+	if err := db.Exec("SELECT drop_old_partitions(3)").Error; err != nil {
+		t.Fatalf("drop_old_partitions not callable: %v", err)
+	}
+}

--- a/pkg/model/retention_test.go
+++ b/pkg/model/retention_test.go
@@ -135,52 +135,33 @@ func TestDeleteOldRowsFloorsKeepMonths(t *testing.T) {
 	}
 }
 
+// TestRunRetention is a smoke test: RunRetention must not panic or return an error signal
+// (it has no return value) regardless of which real message tables exist in the target DB and
+// what shape they are in. It deliberately does NOT seed or delete rows in any real message
+// table (blocks, block_headers, handshakes, mining_ons, subtrees, best_block_requests,
+// node_statuses) — those tables may be shared/real data even in a "throwaway" test DB, and the
+// per-table shape routing behavior is covered in isolation by
+// TestDeleteOldRowsRoutesByShape using disposable tables.
 func TestRunRetention(t *testing.T) {
 	db := testDB(t)
 	log := testLog()
 	if err := EnsureRetentionObjects(db, log); err != nil {
 		t.Fatalf("ensure: %v", err)
 	}
-	// Must not panic or block even when the plain tables are absent/empty; it logs and continues.
+	// Must not panic or block, whatever shape/existence the real message tables have.
 	RunRetention(db, log, 3)
-
-	// Behavioral check: RunRetention actually prunes old rows from a plain-table-shaped table
-	// registered in plainTables' place via direct deleteOldRows call is covered elsewhere; here
-	// we verify RunRetention drives an end-to-end prune against a real plain table using the
-	// production plainTables list, by seeding one of them directly.
-	db.Exec("DROP TABLE IF EXISTS best_block_requests_run_retention_bak")
-	// Use the real best_block_requests table (part of plainTables) so RunRetention's internal
-	// call to deleteOldRows(plainTables) actually exercises it.
-	if err := db.Exec("CREATE TABLE IF NOT EXISTS best_block_requests (id bigserial primary key, network varchar(20) not null default 'test', peer_id varchar(100) not null default 'test', received_at timestamptz NOT NULL default now())").Error; err != nil {
-		t.Fatalf("ensure best_block_requests exists: %v", err)
-	}
-	db.Exec("DELETE FROM best_block_requests")
-	t.Cleanup(func() { db.Exec("DELETE FROM best_block_requests") })
-
-	if err := db.Exec(`INSERT INTO best_block_requests (network, peer_id, received_at)
-		VALUES ('test', 'test-peer', date_trunc('month', now()) - interval '12 months')`).Error; err != nil {
-		t.Fatalf("seed old row: %v", err)
-	}
-	if err := db.Exec(`INSERT INTO best_block_requests (network, peer_id, received_at)
-		VALUES ('test', 'test-peer', now())`).Error; err != nil {
-		t.Fatalf("seed current row: %v", err)
-	}
-
-	RunRetention(db, log, 3)
-
-	var remaining int64
-	db.Raw("SELECT count(*) FROM best_block_requests").Scan(&remaining)
-	if remaining != 1 {
-		t.Fatalf("RunRetention should have pruned the old row and kept the current one, got %d remaining rows", remaining)
-	}
 }
 
-// TestDeleteOldRowsPartitionSafe is a regression guard for the ctid-based batched delete bug:
-// ctid is only unique within a single heap file, so on a PARTITIONED table a ctid-based delete
-// can match and delete rows in the WRONG partition if they happen to share the same ctid slot.
-// This test forces that collision (both partitions' first row gets ctid (0,1)) and asserts the
-// in-window row survives. It FAILS against the old `WHERE ctid IN (...)` implementation and
-// PASSES against the id-based implementation.
+// TestDeleteOldRowsPartitionSafe was originally a regression guard for the ctid-based batched
+// delete bug: ctid is only unique within a single heap file, so on a PARTITIONED table a
+// ctid-based delete could match and delete rows in the WRONG partition if they happened to
+// share the same ctid slot. Since deleteOldRows now routes by runtime relkind (see F1) and
+// SKIPS partitioned tables entirely — leaving them to drop_old_partitions — that bug class is
+// moot for this function. This test now asserts the (stronger) current invariant: deleteOldRows
+// must not touch a partitioned table's rows AT ALL, old or in-window. It still forces the ctid
+// collision from the original bug as a belt-and-suspenders check: even if some future change
+// re-introduced row-level deletes against partitioned tables, a naive ctid-based delete would
+// still be unsafe.
 func TestDeleteOldRowsPartitionSafe(t *testing.T) {
 	db := testDB(t)
 	log := testLog()
@@ -238,12 +219,99 @@ func TestDeleteOldRowsPartitionSafe(t *testing.T) {
 	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", oldPart)).Scan(&oldRemaining)
 	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", curPart)).Scan(&curRemaining)
 
-	if oldRemaining != 0 {
-		t.Fatalf("old-partition row should have been deleted, got %d remaining", oldRemaining)
+	// deleteOldRows must SKIP the partitioned parent entirely (relkind='p') and leave both
+	// rows untouched — pruning partitioned tables is drop_old_partitions' job.
+	if oldRemaining != 1 {
+		t.Fatalf("partitioned table must be skipped by deleteOldRows; old-partition row should still be present, got %d remaining", oldRemaining)
 	}
 	if curRemaining != 1 {
-		t.Fatalf("current-partition row must survive (partition-unsafe delete would have removed it), got %d remaining", curRemaining)
+		t.Fatalf("partitioned table must be skipped by deleteOldRows; current-partition row should still be present, got %d remaining", curRemaining)
 	}
+}
+
+// TestDeleteOldRowsRoutesByShape is the core regression test for F1: deleteOldRows must decide
+// per-table, at runtime, whether to DELETE (plain, relkind='r') or skip (partitioned, relkind='p',
+// or nonexistent). It creates one throwaway PLAIN table, one throwaway PARTITIONED table (RANGE
+// on received_at, mirroring the shape migrations/001 and local docker use for these message
+// tables), and references a table name that doesn't exist at all — then asserts:
+//   - the plain table's old rows are deleted and in-window rows are kept
+//   - the partitioned table is completely untouched (both old and in-window rows survive) —
+//     pruning it is drop_old_partitions' job, not deleteOldRows'
+//   - the nonexistent table produces no error (silently skipped)
+func TestDeleteOldRowsRoutesByShape(t *testing.T) {
+	db := testDB(t)
+	log := testLog()
+
+	const (
+		plainName = "retention_routes_plain_test"
+		partName  = "retention_routes_part_test"
+		missing   = "retention_nonexistent_xyz"
+	)
+
+	db.Exec("DROP TABLE IF EXISTS " + plainName)
+	if err := db.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id bigserial primary key, received_at timestamptz NOT NULL)", plainName)).Error; err != nil {
+		t.Fatalf("create plain table: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS " + plainName) })
+
+	db.Exec("DROP TABLE IF EXISTS " + partName)
+	if err := db.Exec(fmt.Sprintf(
+		`CREATE TABLE %s (id bigserial, received_at timestamptz NOT NULL, PRIMARY KEY (id, received_at)) PARTITION BY RANGE (received_at)`,
+		partName)).Error; err != nil {
+		t.Fatalf("create partitioned parent: %v", err)
+	}
+	t.Cleanup(func() { db.Exec("DROP TABLE IF EXISTS " + partName) })
+
+	mkPartition := func(offsetMonths int) string {
+		var name, start, end string
+		db.Raw(`SELECT ? || '_' || to_char(date_trunc('month', CURRENT_DATE) + make_interval(months => ?), 'YYYY_MM')`, partName, offsetMonths).Scan(&name)
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths).Scan(&start)
+		db.Raw(`SELECT (date_trunc('month', CURRENT_DATE) + make_interval(months => ?))::text`, offsetMonths+1).Scan(&end)
+		if err := db.Exec(fmt.Sprintf(`CREATE TABLE %s PARTITION OF %s FOR VALUES FROM ('%s') TO ('%s')`, name, partName, start, end)).Error; err != nil {
+			t.Fatalf("create partition %s: %v", name, err)
+		}
+		return name
+	}
+	oldPart := mkPartition(-6)
+	curPart := mkPartition(0)
+
+	// Seed both tables with one old row (well outside a 3-month window) and one in-window row.
+	if err := db.Exec(fmt.Sprintf(
+		`INSERT INTO %s (received_at) VALUES (date_trunc('month', now()) - interval '12 months'), (now())`, plainName)).Error; err != nil {
+		t.Fatalf("seed plain table: %v", err)
+	}
+	if err := db.Exec(fmt.Sprintf(
+		`INSERT INTO %s (received_at) VALUES ((date_trunc('month', CURRENT_DATE) + make_interval(months => -6) + interval '10 days'))`, partName)).Error; err != nil {
+		t.Fatalf("seed partitioned old row: %v", err)
+	}
+	if err := db.Exec(fmt.Sprintf(
+		`INSERT INTO %s (received_at) VALUES (now())`, partName)).Error; err != nil {
+		t.Fatalf("seed partitioned current row: %v", err)
+	}
+
+	if err := deleteOldRows(db, log, 3, []string{plainName, partName, missing}); err != nil {
+		t.Fatalf("deleteOldRows: %v", err)
+	}
+
+	var plainRemaining int64
+	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", plainName)).Scan(&plainRemaining)
+	if plainRemaining != 1 {
+		t.Fatalf("plain table: expected old row deleted and in-window row kept (1 remaining), got %d", plainRemaining)
+	}
+
+	var oldPartRemaining, curPartRemaining int64
+	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", oldPart)).Scan(&oldPartRemaining)
+	db.Raw(fmt.Sprintf("SELECT count(*) FROM %s", curPart)).Scan(&curPartRemaining)
+	if oldPartRemaining != 1 {
+		t.Fatalf("partitioned table must be left untouched by deleteOldRows; old partition should still have its row, got %d", oldPartRemaining)
+	}
+	if curPartRemaining != 1 {
+		t.Fatalf("partitioned table must be left untouched by deleteOldRows; current partition should still have its row, got %d", curPartRemaining)
+	}
+
+	// The nonexistent table must not produce an error — confirmed by deleteOldRows returning
+	// nil above already covering all three tables in one call.
 }
 
 func TestDropOldPartitions(t *testing.T) {


### PR DESCRIPTION
## Problem

The Postgres volume filled to 100% and crashlooped (`PANIC: could not write ... No space left on device`). Root cause: no data retention. The app stored every P2P message from all networks forever.

Two defects behind it:
- `partition_cleanup_days: 90` in `config.yaml` was dead config — nothing in Go ever read it.
- Only `node_statuses` was ever actually partitioned. `create_monthly_partitions()` listed 5 other tables that are plain GORM tables, so its `CREATE TABLE ... PARTITION OF` calls failed silently every run.

Measured on the live DB (39 GB): `rejected_txes` 15 GB (dead — feature removed in a31e3e0, last write 2026-05-22), `node_statuses` ~21 GB across 9 monthly partitions, `subtrees` 3.3 GB, rest small.

## What this does

Adds a real retention system driven from the existing daily ticker, retention window `partition_retention_months` (default 3 = current + 2 prior months):

- **Drops the dead `rejected_txes` table** on startup (~15 GB).
- **`drop_old_partitions()`** — drops `node_statuses` month-partitions older than the window (instant, frees the OS). Scans all partitioned tables (`relkind='p'`) so any future partitioned table is covered.
- **`deleteOldRows()`** — batched row-DELETE (id-based, 20k/batch) for plain tables. Autovacuum reuses freed pages; tables plateau instead of growing.
- **Runtime schema-shape routing** — each message table's shape is detected at runtime via `pg_class.relkind`: partitioned tables (`relkind='p'`) are pruned by dropping old partitions, plain tables (`relkind='r'`) by row-DELETE, nonexistent tables skipped. This is deliberate: the live/prod DB has these tables **plain** (built by GORM AutoMigrate), while `migrations/001` provisions them **partitioned** — the code is correct on both shapes instead of assuming one.
- **`create_monthly_partitions()` runs synchronously before P2P subscribe** so partitioned tables always have current/next partitions before any insert.

### Hardening (from multiple fresh-context review passes)
- Both plpgsql functions are **scoped to an explicit table allowlist** (can't touch a co-tenant partitioned table) and set `SET LOCAL lock_timeout = '5s'` (a conflicting lock degrades to a logged error instead of hanging startup).
- `drop_old_partitions` **verifies a partition holds no in-window rows before dropping** it — safe even if a partition's real bound is wider than its `_YYYY_MM` name implies.
- `received_at` indexes for the row-DELETE path are created by the app (`EnsureRetentionObjects`), not left to depend on AutoMigrate — avoids a seq-scan first run.
- `RunRetention` emits a distinct final log line (`OK` / `WITH FAILURES — disk may grow unbounded`) so silent retention failure is greppable.
- Test harness refuses a non-localhost DSN (destructive tests can't be aimed at a remote/prod DB by accident); id-based DELETE validates table names; `rejected_txes` drop is schema-qualified.
- Config knob replaces the dead `partition_cleanup_days`; `EnsureRetentionObjects` (functions + `DROP rejected_txes`) runs synchronously post-AutoMigrate, the slow prune runs in the async 24h goroutine so it never blocks pod readiness.
- Reference `migrations/003_retention.sql` (app has no migration runner — installs the functions at startup) + `CLAUDE.md` notes + `received_at` indexes on the plain tables.

## Why DELETE, not partition-convert

Converting the 5 plain tables to partitioned would recover only ~2 GB now but forces drop+recreate of the 3 materialized views that read `blocks`/`handshakes`/`mining_ons`, plus composite-PK/sequence rework and a boot-time copy. Not worth it for a POC viewer. DELETE's only downside — disk not returned to the OS without a locking `VACUUM FULL` — is acceptable; growth stops.

## Deploy effect

Next deploy auto-reclaims ~32 GB → DB ~7 GB on disk. No manual DB surgery. (The 50Gi PVC bump made to bring the DB back online wasn't strictly needed post-cleanup, but is harmless — EBS can't shrink.)

## Testing

Go integration tests in `pkg/model/retention_test.go`, gated on `TERANODE_P2P_TEST_DSN` (skip if unset; **point it only at a throwaway DB** — the tests call `drop_old_partitions`, which scans all partitioned tables). Covers cutoff month-boundary (keep-at-cutoff, delete-before), `keepMonths` floor, partition drop/keep, and a partition-safe delete regression test.

Note: the id-based (not ctid) delete is deliberate — ctid is unique only within one heap file, so a ctid-based batched delete silently deletes wrong rows on a partitioned table. `TestDeleteOldRowsPartitionSafe` guards this.