### PR TITLE
fix(security): confine static-file path + least-privilege workflow perms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,11 @@ on:
       - master
   workflow_dispatch:
 
+# Least-privilege default for GITHUB_TOKEN across all jobs; the build-and-push
+# job widens this to packages: write where it actually needs it.
+permissions:
+  contents: read
+
 jobs:
   get_tag:
     runs-on: ubuntu-latest

--- a/pkg/http/server.go
+++ b/pkg/http/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -1087,13 +1088,20 @@ func InitServer(log *logrus.Logger, db *gorm.DB, statsService *service.StatsServ
 	}))
 
 	// Static file serving for React app - MUST be registered last
+	const reactBuildDir = "./frontend-react/build"
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		// Check if the requested file exists in React build
-		path := "./frontend-react/build" + r.URL.Path
-		if _, err := os.Stat(path); err == nil {
-			// File exists, serve it
-			http.FileServer(http.Dir("./frontend-react/build")).ServeHTTP(w, r)
-			return
+		// Confine the requested path to reactBuildDir before touching the
+		// filesystem to prevent path traversal (CodeQL go/path-injection).
+		// filepath.Clean("/"+path) roots the request so ".." segments cannot
+		// escape, and the prefix check rejects anything outside the build dir.
+		candidate := filepath.Join(reactBuildDir, filepath.Clean("/"+r.URL.Path))
+		if candidate == filepath.Clean(reactBuildDir) ||
+			strings.HasPrefix(candidate, filepath.Clean(reactBuildDir)+string(os.PathSeparator)) {
+			if _, err := os.Stat(candidate); err == nil {
+				// File exists within the build dir, serve it
+				http.FileServer(http.Dir(reactBuildDir)).ServeHTTP(w, r)
+				return
+			}
 		}
 
 		// For any non-existent path, serve index.html (for React Router)


### PR DESCRIPTION
## What

Clears both open CodeQL code-scanning alerts.

### 1. Path injection — `pkg/http/server.go` (high, `go/path-injection`)

The catch-all `/` static handler built a filesystem path by concatenating the
raw request path (`"./frontend-react/build" + r.URL.Path`) and `os.Stat`'d it.
A crafted `../` path could probe for the existence of arbitrary files outside
the build directory (information disclosure).

Fix: root and clean the request (`filepath.Clean("/"+r.URL.Path)`), `filepath.Join`
it onto the build dir, and confine it with a prefix check before any filesystem
access. `http.FileServer`/`http.Dir` already sanitizes what it actually serves;
this closes the `os.Stat` probe that CodeQL flagged.

Verified with a scratch harness — every traversal attempt stays inside the build root:

```
in="/../../etc/passwd"       -> candidate="frontend-react/build/etc/passwd"  allowed=true
in="/../../../../etc/passwd" -> candidate="frontend-react/build/etc/passwd"  allowed=true
```

(`allowed=true` is fine — the point is the *resolved* path never escapes the build dir.)

### 2. Missing workflow permissions — `.github/workflows/build.yml` (medium)

The `get_tag` job ran with the default, overly-broad `GITHUB_TOKEN`. Added a
top-level `permissions: contents: read` default. The `build-and-push` job keeps
its explicit `contents: read` + `packages: write`.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/http/` — clean
